### PR TITLE
Add version 2.6 to PMD Plugin -> PMD mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ SonarQube PMD Plugin
 ## Description / Features
 This plugin provides coding rules from [PMD](https://pmd.github.io/).
 
-PMD Plugin|2.0|2.1|2.2|2.3|2.4.1|2.5
--------|---|---|---|---|---|---
-PMD|4.3|4.3|5.1.1|5.2.1|5.3.1|5.4.0
+PMD Plugin|2.0|2.1|2.2|2.3|2.4.1|2.5|2.6
+-------|---|---|---|---|---|---|---
+PMD|4.3|4.3|5.1.1|5.2.1|5.3.1|5.4.0|5.4.2
 
 A majority of the PMD rules have been rewritten in the Java plugin. Rewritten rules are marked "Deprecated" in the PMD plugin, but a [concise summary of replaced rules](http://dist.sonarsource.com/reports/coverage/pmd.html) is available.
 


### PR DESCRIPTION
As I see 2.6 was released.  Maybe add this version to table at README?